### PR TITLE
upgrade aws-lambda-api-gateway-proxy to terraform v0.12

### DIFF
--- a/aws-lambda-api-gateway-proxy/api_gateway.tf
+++ b/aws-lambda-api-gateway-proxy/api_gateway.tf
@@ -1,47 +1,47 @@
 resource "aws_api_gateway_rest_api" "api" {
-  name = "${var.api_gateway_name}"
+  name = var.api_gateway_name
 }
 
 resource "aws_api_gateway_resource" "resource" {
   path_part   = "{proxy+}"
-  parent_id   = "${aws_api_gateway_rest_api.api.root_resource_id}"
-  rest_api_id = "${aws_api_gateway_rest_api.api.id}"
+  parent_id   = aws_api_gateway_rest_api.api.root_resource_id
+  rest_api_id = aws_api_gateway_rest_api.api.id
 }
 
 resource "aws_api_gateway_method" "method" {
-  rest_api_id   = "${aws_api_gateway_rest_api.api.id}"
-  resource_id   = "${aws_api_gateway_resource.resource.id}"
+  rest_api_id   = aws_api_gateway_rest_api.api.id
+  resource_id   = aws_api_gateway_resource.resource.id
   http_method   = "POST"
   authorization = "NONE"
 }
 
 resource "aws_api_gateway_integration" "integration" {
-  depends_on              = ["aws_api_gateway_method.method"]
-  rest_api_id             = "${aws_api_gateway_rest_api.api.id}"
-  resource_id             = "${aws_api_gateway_resource.resource.id}"
-  http_method             = "${aws_api_gateway_method.method.http_method}"
+  depends_on              = [aws_api_gateway_method.method]
+  rest_api_id             = aws_api_gateway_rest_api.api.id
+  resource_id             = aws_api_gateway_resource.resource.id
+  http_method             = aws_api_gateway_method.method.http_method
   integration_http_method = "POST"
   type                    = "AWS_PROXY"
   uri                     = "arn:aws:apigateway:${var.region}:lambda:path/2015-03-31/functions/arn:aws:lambda:${var.region}:${data.aws_caller_identity.current.account_id}:function:${aws_lambda_function.lambda.function_name}/invocations"
 }
 
-resource "aws_api_gateway_method_response" "200" {
-  rest_api_id = "${aws_api_gateway_rest_api.api.id}"
-  resource_id = "${aws_api_gateway_resource.resource.id}"
-  http_method = "${aws_api_gateway_method.method.http_method}"
+resource "aws_api_gateway_method_response" "status_ok_200" {
+  rest_api_id = aws_api_gateway_rest_api.api.id
+  resource_id = aws_api_gateway_resource.resource.id
+  http_method = aws_api_gateway_method.method.http_method
   status_code = "200"
 }
 
 resource "aws_api_gateway_integration_response" "integration_response" {
   depends_on = [
-    "aws_api_gateway_method.method",
-    "aws_api_gateway_integration.integration",
+    aws_api_gateway_method.method,
+    aws_api_gateway_integration.integration,
   ]
 
-  rest_api_id = "${aws_api_gateway_rest_api.api.id}"
-  resource_id = "${aws_api_gateway_resource.resource.id}"
-  http_method = "${aws_api_gateway_method.method.http_method}"
-  status_code = "${aws_api_gateway_method_response.200.status_code}"
+  rest_api_id = aws_api_gateway_rest_api.api.id
+  resource_id = aws_api_gateway_resource.resource.id
+  http_method = aws_api_gateway_method.method.http_method
+  status_code = aws_api_gateway_method_response.status_ok_200.status_code
 
   response_templates = {
     "application/json" = ""
@@ -50,10 +50,11 @@ resource "aws_api_gateway_integration_response" "integration_response" {
 
 resource "aws_api_gateway_deployment" "deployment" {
   depends_on = [
-    "aws_api_gateway_method.method",
-    "aws_api_gateway_integration.integration",
+    aws_api_gateway_method.method,
+    aws_api_gateway_integration.integration,
   ]
 
-  rest_api_id = "${aws_api_gateway_rest_api.api.id}"
-  stage_name  = "${var.api_gateway_deployment_name}"
+  rest_api_id = aws_api_gateway_rest_api.api.id
+  stage_name  = var.api_gateway_deployment_name
 }
+

--- a/aws-lambda-api-gateway-proxy/lambda.tf
+++ b/aws-lambda-api-gateway-proxy/lambda.tf
@@ -2,18 +2,18 @@
 resource "aws_lambda_permission" "apigw_lambda" {
   statement_id  = "AllowExecutionFromAPIGateway"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.lambda.arn}"
+  function_name = aws_lambda_function.lambda.arn
   principal     = "apigateway.amazonaws.com"
   source_arn    = "arn:aws:execute-api:${var.region}:${data.aws_caller_identity.current.account_id}:${aws_api_gateway_rest_api.api.id}/*/${aws_api_gateway_method.method.http_method}${aws_api_gateway_resource.resource.path}"
 }
 
 resource "aws_lambda_function" "lambda" {
-  filename         = "${data.archive_file.lambda_zip.output_path}"
-  function_name    = "mylambda"
-  role             = "${aws_iam_role.role.arn}"
+  filename         = data.archive_file.lambda_zip.output_path
+  function_name    = var.lambda_name
+  role             = aws_iam_role.role.arn
   handler          = "${var.lambda_name}.handler"
-  runtime          = "${var.runtime}"
-  source_code_hash = "${data.archive_file.lambda_zip.output_base64sha256}"
+  runtime          = var.runtime
+  source_code_hash = data.archive_file.lambda_zip.output_base64sha256
 }
 
 # IAM role
@@ -35,4 +35,6 @@ resource "aws_iam_role" "role" {
   ]
 }
 POLICY
+
 }
+

--- a/aws-lambda-api-gateway-proxy/main.tf
+++ b/aws-lambda-api-gateway-proxy/main.tf
@@ -1,11 +1,15 @@
-provider "aws" {}
+provider "aws" {
+}
 
-provider "archive" {}
+provider "archive" {
+}
 
-data "aws_caller_identity" "current" {}
+data "aws_caller_identity" "current" {
+}
 
 data "archive_file" "lambda_zip" {
   type        = "zip"
   output_path = "${var.lambda_name}.zip"
-  source_dir  = "${var.project_src}"
+  source_dir  = var.project_src
 }
+

--- a/aws-lambda-api-gateway-proxy/outputs.tf
+++ b/aws-lambda-api-gateway-proxy/outputs.tf
@@ -1,3 +1,4 @@
 output "base_url" {
-  value = "${aws_api_gateway_deployment.deployment.invoke_url}"
+  value = aws_api_gateway_deployment.deployment.invoke_url
 }
+

--- a/aws-lambda-api-gateway-proxy/vars.tf
+++ b/aws-lambda-api-gateway-proxy/vars.tf
@@ -1,9 +1,9 @@
 variable "lambda_name" {
-  description = "The name of the lambda"
+  description = "The name of the lambda function"
 }
 
 variable "runtime" {
-  default     = "nodejs6.10"
+  default     = "nodejs12.x"
   description = "The lambda runtime"
 }
 
@@ -26,3 +26,4 @@ variable "output_path" {
 variable "api_gateway_deployment_name" {
   description = "The name of the API gateway deployment"
 }
+

--- a/aws-lambda-api-gateway-proxy/versions.tf
+++ b/aws-lambda-api-gateway-proxy/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
# Summary

Upgrade the aws-lambda-api-gateway-proxy module to support terraform v0.12