### PR TITLE
feature: initial terraform-aws-s3-cloudfront-cdn

### DIFF
--- a/terraform-aws-s3-cloudfront-cdn/main.tf
+++ b/terraform-aws-s3-cloudfront-cdn/main.tf
@@ -1,0 +1,85 @@
+locals {
+  s3_origin_id = var.origin_id
+}
+
+resource "aws_s3_bucket" "b" {
+  bucket = var.bucket_name
+  acl    = "public-read"
+
+  versioning {
+    enabled = true
+  }
+  tags = {
+    Environment = var.environment_tag
+  }
+}
+
+data "aws_iam_policy_document" "b" {
+  statement {
+    principals {
+      type = "AWS"
+      identifiers = [
+        aws_cloudfront_origin_access_identity.origin_access_identity.iam_arn
+      ]
+    }
+
+    actions   = ["s3:GetObject"]
+    resources = ["arn:aws:s3:::${var.bucket_name}/*"]
+  }
+}
+
+resource "aws_s3_bucket_policy" "b" {
+  bucket = aws_s3_bucket.b.id
+  policy = data.aws_iam_policy_document.b.json
+}
+
+resource "aws_cloudfront_origin_access_identity" "origin_access_identity" {}
+
+resource "aws_cloudfront_distribution" "s3_distribution" {
+  origin {
+    domain_name = "${aws_s3_bucket.b.bucket_regional_domain_name}"
+    origin_id   = "${local.s3_origin_id}"
+
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path
+    }
+  }
+
+  enabled         = true
+  is_ipv6_enabled = true
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = local.s3_origin_id
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "allow-all"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+  }
+
+  price_class = var.price_class
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  tags = {
+    Environment = var.environment_tag
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+}

--- a/terraform-aws-s3-cloudfront-cdn/outputs.tf
+++ b/terraform-aws-s3-cloudfront-cdn/outputs.tf
@@ -1,0 +1,31 @@
+output "cloudfront_id" {
+  value = aws_cloudfront_distribution.s3_distribution.id
+}
+
+output "cloudfront_arn" {
+  value = aws_cloudfront_distribution.s3_distribution.arn
+}
+
+output "cloudfront_status" {
+  value = aws_cloudfront_distribution.s3_distribution.status
+}
+
+output "cloudfront_domain_name" {
+  value = aws_cloudfront_distribution.s3_distribution.domain_name
+}
+
+output "bucket_id" {
+  value = aws_s3_bucket.b.id
+}
+
+output "bucket_arn" {
+  value = aws_s3_bucket.b.arn
+}
+
+output "bucket_bucket_domain_name" {
+  value = aws_s3_bucket.b.bucket_domain_name
+}
+
+output "bucket_bucket_regional_domain_name" {
+  value = aws_s3_bucket.b.bucket_regional_domain_name
+}

--- a/terraform-aws-s3-cloudfront-cdn/vars.tf
+++ b/terraform-aws-s3-cloudfront-cdn/vars.tf
@@ -1,0 +1,17 @@
+variable "bucket_name" {
+  description = "Name of the bucket the resources will be stored"
+}
+
+variable "environment_tag" {
+  description = "Value for the 'Environment' tag"
+  default     = "production"
+}
+
+variable "origin_id" {
+  description = "ID for the bucket origin"
+}
+
+variable "price_class" {
+  description = "Price class for the cloudfront distribution"
+  default     = "PriceClass_100"
+}

--- a/terraform-aws-s3-cloudfront-cdn/versions.tf
+++ b/terraform-aws-s3-cloudfront-cdn/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
# Summary

Base module configuration for a basic cloudfront CDN backed by an AWS S3 bucket. 

*note* This configuration does not allow for the setting of aliases or providing custom certificates.