### PR TITLE
feat: terraform-aws-ses-s3-storage

### DIFF
--- a/terraform-aws-ses-s3-storage/README.md
+++ b/terraform-aws-ses-s3-storage/README.md
@@ -1,0 +1,54 @@
+# AWS-SES-S3-STORAGE
+
+This module is used to configure an AWS SES service to receive emails from a specified
+domain and store them in an s3 bucket.
+
+## Usage
+
+### DNS Provisioning
+
+After using terraform to create the resources, you will need to provision the DNS
+records to finish the configuration.
+
+#### Validating the Domain
+
+Create a `TXT` record for the domain using your DNS provider. The challenge details
+will be located on the AWS SES console under the domain you are registering.
+
+This module also provides the "aws_ses_domain_identity_verification_token" output,
+which is the value of the `TXT` record.
+
+The `TXT` record should have:
+
+```
+name: "_amazonses.<your domain>"
+value: "<aws_ses_domain_identity_verification_token>"
+```
+
+Once completed, the verification "pending" status will be replaced with "verified".
+
+#### Configuring the MX record
+
+Next you will need to create an `MX` record to route all incoming mail traffic to the
+aws SES server. Again, instructions are provided on the AWS console.
+
+The name should be your domain (or subdomain) and the value is the location of the
+server.
+
+### Variables
+
+| Variable                    | Description                                          | required | default |
+| --------------------------- | ---------------------------------------------------- | -------- | ------- |
+| bucket_name                 | name of the s3 bucket the raw emails will be stored  | yes      | none    |
+| domain                      | the domain to registered for use with SES            | yes      | none    |
+| recipients                  | list of recipients that the store action will run on | yes      | none    |
+| s3_bucket_object_key_prefix | prefix the emails will be stored under               | no       | ""      |
+
+### Outputs
+
+| Output                                     | Description                                     |
+| ------------------------------------------ | ----------------------------------------------- |
+| bucket_id                                  | id of the email storage bucket                  |
+| bucket_arn                                 | arn of the email storage bucket                 |
+| aws_ses_active_rule_set_name               | name of the active rule set                     |
+| aws_ses_domain_identity_verification_token | token required to validate the domain challenge |

--- a/terraform-aws-ses-s3-storage/main.tf
+++ b/terraform-aws-ses-s3-storage/main.tf
@@ -1,0 +1,78 @@
+resource "aws_s3_bucket" "reports_bucket" {
+  bucket = var.bucket_name
+}
+
+resource "aws_s3_bucket_public_access_block" "reports_bucket_storage_storage_access_rules" {
+  bucket = aws_s3_bucket.reports_bucket.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_policy" "reports_bucket_policy" {
+  bucket = aws_s3_bucket.reports_bucket.id
+  policy = data.aws_iam_policy_document.ses_write_to_s3.json
+  depends_on = [
+    aws_s3_bucket.reports_bucket,
+    aws_s3_bucket_public_access_block.reports_bucket_storage_storage_access_rules
+  ]
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_policy_document" "ses_write_to_s3" {
+  statement {
+    sid = "AllowSESPuts"
+
+    actions = ["s3:PutObject"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ses.amazonaws.com"]
+    }
+
+    resources = ["arn:aws:s3:::${var.bucket_name}/*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:Referer"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+  }
+}
+
+resource "aws_ses_domain_identity" "primary_domain" {
+  domain = var.domain
+}
+
+resource "aws_ses_receipt_rule_set" "store" {
+  rule_set_name = "store_receive_all"
+}
+
+resource "aws_ses_active_receipt_rule_set" "store" {
+  rule_set_name = aws_ses_receipt_rule_set.store.rule_set_name
+  depends_on = [
+    aws_ses_receipt_rule.store
+  ]
+}
+
+resource "aws_ses_receipt_rule" "store" {
+  name          = "store"
+  rule_set_name = aws_ses_receipt_rule_set.store.rule_set_name
+  recipients    = var.recipients
+  enabled       = true
+  scan_enabled  = true
+
+  s3_action {
+    position          = 1
+    bucket_name       = var.bucket_name
+    object_key_prefix = var.s3_bucket_object_key_prefix
+  }
+
+  depends_on = [
+    aws_s3_bucket.reports_bucket,
+    aws_s3_bucket_policy.reports_bucket_policy,
+  ]
+}

--- a/terraform-aws-ses-s3-storage/outputs.tf
+++ b/terraform-aws-ses-s3-storage/outputs.tf
@@ -1,0 +1,15 @@
+output "bucket_id" {
+  value = aws_s3_bucket.reports_bucket.id
+}
+
+output "bucket_arn" {
+  value = aws_s3_bucket.reports_bucket.arn
+}
+
+output "aws_ses_active_rule_set_name" {
+  value = aws_ses_receipt_rule_set.store.rule_set_name
+}
+
+output "aws_ses_domain_identity_verification_token" {
+  value = aws_ses_domain_identity.primary_domain.verification_token
+}

--- a/terraform-aws-ses-s3-storage/vars.tf
+++ b/terraform-aws-ses-s3-storage/vars.tf
@@ -1,0 +1,17 @@
+variable "bucket_name" {
+  description = "the name of the s3 bucket the raw emails will be stored"
+}
+
+variable "domain" {
+  description = "the domain to registered for use with SES"
+}
+
+variable "recipients" {
+  type        = list(string)
+  description = "list of recipients that the store action will run on"
+}
+
+variable "s3_bucket_object_key_prefix" {
+  description = "The prefix (path) the raw emails will be stored in the bucket"
+  default     = ""
+}


### PR DESCRIPTION
# Summary

Terraform module for configuring an SES service to store emails in an S3 bucket

# Test Plan

- Import and use the module, the resources should be successfully created without errors
- delete the SES initialization file created in the s3 bucket 
- tear down the infrastructure, this should also succeed.

Example `main.tf`:
```hcl
provider "aws" {}

variable "domain" {
  default = "some.domainyouown.com"
}

module "ses" {
  source = "../../../autotelic/infrastructure-modules/terraform-aws-ses-s3-storage"
  bucket_name = "some-bucket-for-emails"
  domain = var.domain
  recipients  = [var.domain]
  s3_bucket_object_key_prefix = "raw"
}
```