### PR TITLE
feat: add s3 triggered lambda module

### DIFF
--- a/terraform-aws-s3-trigger-lambda/README.md
+++ b/terraform-aws-s3-trigger-lambda/README.md
@@ -1,0 +1,24 @@
+# AWS-S3-TRIGGER-LAMBDA
+
+This module is used to configure an AWS Lambda that will be triggered when an object
+is written to an s3 bucket.
+
+## Usage
+
+### Variables
+
+| Variable    | Description                                              | required | default |
+| ----------- | -------------------------------------------------------- | -------- | ------- |
+| bucket_id   | ID of the s3 bucket that triggers the lambda             | yes      | none    |
+| bucket_arn  | arn of the s3 bucket that triggers the lambda            | yes      | none    |
+| s3_prefix   | A prefix that s3 objects must have to trigger the lambda | no       | "/"     |
+| lambda_name | Name of the lambda function                              | yes      | none    |
+| runtime     | Lambda function runtime                                  | yes      | none    |
+| project_src | Directory that will be zipped to create the lambda       | yes      | none    |
+
+### Outputs
+
+| Output               | Description                                                             |
+| -------------------- | ----------------------------------------------------------------------- |
+| lambda_arn           | The Amazon Resource Name (ARN) identifying your Lambda Function         |
+| lambda_iam_role_name | The name of the IAM role where IAM policies for the lambda are attached |

--- a/terraform-aws-s3-trigger-lambda/main.tf
+++ b/terraform-aws-s3-trigger-lambda/main.tf
@@ -1,0 +1,80 @@
+data "archive_file" "lambda_zip" {
+  type        = "zip"
+  output_path = "${var.lambda_name}.zip"
+  source_dir  = var.project_src
+}
+
+resource "aws_lambda_permission" "allow_bucket" {
+  statement_id  = "AllowExecutionFromS3Bucket"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.func.arn
+  principal     = "s3.amazonaws.com"
+  source_arn    = var.bucket_arn
+}
+
+resource "aws_lambda_function" "func" {
+  filename      = data.archive_file.lambda_zip.output_path
+  function_name = var.lambda_name
+  role          = aws_iam_role.iam_for_lambda.arn
+  handler       = "index.handler"
+  runtime       = var.runtime
+}
+
+resource "aws_s3_bucket_notification" "bucket_notification" {
+  bucket = var.bucket_id
+
+  lambda_function {
+    lambda_function_arn = aws_lambda_function.func.arn
+    events              = ["s3:ObjectCreated:*"]
+    filter_prefix       = var.s3_prefix
+  }
+
+  depends_on = [aws_lambda_permission.allow_bucket]
+}
+
+resource "aws_iam_role" "iam_for_lambda" {
+  name = "iam_for_lambda"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_policy" "lambda_logging" {
+  name        = "lambda_logging"
+  path        = "/"
+  description = "IAM policy for logging from a lambda"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:*:*:*",
+      "Effect": "Allow"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_logs" {
+  role       = aws_iam_role.iam_for_lambda.name
+  policy_arn = aws_iam_policy.lambda_logging.arn
+}

--- a/terraform-aws-s3-trigger-lambda/outputs.tf
+++ b/terraform-aws-s3-trigger-lambda/outputs.tf
@@ -1,0 +1,9 @@
+output "lambda_arn" {
+  description = "The Amazon Resource Name (ARN) identifying your Lambda Function"
+  value       = aws_lambda_function.func.arn
+}
+
+output "lambda_iam_role_name" {
+  description = "The name of the IAM role where IAM policies for the lambda are attached"
+  value       = aws_iam_role.iam_for_lambda.name
+}

--- a/terraform-aws-s3-trigger-lambda/vars.tf
+++ b/terraform-aws-s3-trigger-lambda/vars.tf
@@ -1,0 +1,27 @@
+variable "bucket_id" {
+  description = "ID of the s3 bucket that triggers the lambda"
+}
+variable "bucket_arn" {
+  description = "arn of the s3 bucket that triggers the lambda"
+}
+
+variable "s3_prefix" {
+  description = <<EOF
+  A prefix that objects must have to trigger the lambda. Any object written with a different
+  prefix will not invoke the lambda. Prefixes are treated like directories in s3 buckets.
+  Defaults to the root of the bucket.
+EOF
+  default     = "/"
+}
+
+variable "lambda_name" {
+  description = "Name of the lambda function"
+}
+
+variable "runtime" {
+  description = "Lambda function runtime"
+}
+
+variable "project_src" {
+  description = "Directory that will be zipped to create the lambda"
+}


### PR DESCRIPTION
# Summary

Terraform module for configuring an AWS Lambda resource that is triggerd by an s3 object creation event.

# Test Plan

- Import and use the module, the resources should be successfully created without errors
- write a file to the s3 bucket with the `raw` prefix:
```
touch test.txt
aws s3 mv ./test.txt s3://some-testing-bucket-for-review/raw/test.txt
```
- Go to the AWS lambda console, and look at the logs for the created lambda, you should see that it was invoked and logs were written.
- tear down the infrastructure, this should also succeed.

Example `main.tf`:
```hcl
provider "aws" {}

variable "domain" {
  default = "some.domainyouown.com"
}

variable "prefix" {
  default = "raw"
}

module "ses" {
  source                      = "../../../@autotelic/infrastructure-modules/terraform-aws-ses-s3-storage"
  bucket_name                 = "some-testing-bucket-for-review"
  domain                      = var.domain
  recipients                  = [var.domain]
  s3_bucket_object_key_prefix = var.prefix
}

module "s3_triggered_lambda" {
  source      = "../../../@autotelic/infrastructure-modules/terraform-aws-s3-trigger-lambda"
  bucket_id   = module.ses.bucket_id
  bucket_arn  = module.ses.bucket_arn
  lambda_name = "some-lamda-name"
  runtime     = "nodejs12.x"
  project_src = "../src"
  s3_prefix   = "${var.prefix}/"
}
```
With a `src/index.js` file up one directory from your `main.tf` containing:

```js
exports.handler = async function (event, context) {
  console.log('EVENT: \n' + JSON.stringify(event, null, 2));
  return context.logStreamName;
};
```
