### PR TITLE
Initialize terraform-aws-static-site Module

### DIFF
--- a/terraform-aws-static-site/README.md
+++ b/terraform-aws-static-site/README.md
@@ -1,0 +1,14 @@
+# AWS-Static-Site-Module
+This module is used to configure a static site with aws,including two s3 buckets and two cloudfront distributions.
+
+## Usage
+### Variables
+| Variable         | Description                                           | Required? | Default |
+| ---------------- | :---------------------------------------------------- | :-------: | :-----: |
+| bucket_name      | The name of the S3 bucket                             | Yes       | None    |
+| redirect_address | The address to redirect requests to                   | Yes       | None    |
+| origin_id        | The unique ID for the non-www cloudfront distribution | Yes       | None    |
+| aliases          | cNAMEs for the non-www cloudfront distribution        | Yes       | None    |
+| www_origin_id    | The unique ID for the www cloudfront distribution     | Yes       | None    |
+| www_aliases      | cNAMEs for the www cloudfront distribution            | Yes       | None    |
+| acm_arn          | The ARN of the certificate                            | Yes       | None    |

--- a/terraform-aws-static-site/main.tf
+++ b/terraform-aws-static-site/main.tf
@@ -44,8 +44,11 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
     domain_name = aws_s3_bucket.non-www-bucket.bucket_regional_domain_name
     origin_id   = var.origin_id
 
-    custom_origin_config {
+    s3_origin_config {
       origin_access_indentity= aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path
+    }
+
+    custom_origin_config {
       origin_protocol_policy = "http-only"
       http_port              = "80"
       https_port             = "443"

--- a/terraform-aws-static-site/main.tf
+++ b/terraform-aws-static-site/main.tf
@@ -103,10 +103,6 @@ resource "aws_cloudfront_distribution" "www_s3_distribution" {
     domain_name = aws_s3_bucket.www-bucket.bucket_regional_domain_name
     origin_id   = var.www_origin_id
 
-    s3_origin_config {
-      origin_access_identity = aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path
-    }
-    
     custom_origin_config {
       origin_protocol_policy = "http-only"
       http_port              = "80"

--- a/terraform-aws-static-site/main.tf
+++ b/terraform-aws-static-site/main.tf
@@ -1,5 +1,5 @@
 # Non www-bucket
-resource "aws_s3_bucket" "b" {
+resource "aws_s3_bucket" "non-www-bucket" {
   bucket = var.bucket_name
   acl    = "public-read"
 
@@ -9,7 +9,7 @@ resource "aws_s3_bucket" "b" {
   }
 }
 
-data "aws_iam_policy_document" "b" {
+data "aws_iam_policy_document" "non-www-bucket" {
   statement {
     sid    = "PublicReadGetObject"
     effect = "Allow"
@@ -24,9 +24,9 @@ data "aws_iam_policy_document" "b" {
   }
 }
 
-resource "aws_s3_bucket_policy" "b" {
-  bucket = aws_s3_bucket.b.id
-  policy = data.aws_iam_policy_document.b.json
+resource "aws_s3_bucket_policy" "non-www-bucket" {
+  bucket = aws_s3_bucket.non-www-bucket.id
+  policy = data.aws_iam_policy_document.non-www-bucket.json
 }
 
 # www-bucket
@@ -42,7 +42,7 @@ resource "aws_s3_bucket" "www-bucket" {
 # Non www-bucket CDN
 resource "aws_cloudfront_distribution" "s3_distribution" {
   origin {
-    domain_name = aws_s3_bucket.b.bucket_regional_domain_name
+    domain_name = aws_s3_bucket.non-www-bucket.bucket_regional_domain_name
     origin_id   = var.origin_id
 
     custom_origin_config {
@@ -95,7 +95,7 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
     response_page_path    = "/index.html"
   }
   depends_on = [
-    aws_s3_bucket.b
+    aws_s3_bucket.non-www-bucket
   ]
 }
 

--- a/terraform-aws-static-site/main.tf
+++ b/terraform-aws-static-site/main.tf
@@ -31,7 +31,7 @@ resource "aws_s3_bucket_policy" "b" {
 
 # www-bucket
 resource "aws_s3_bucket" "www-bucket" {
-  bucket = "www-${var.www_bucket_name}"
+  bucket = "www-${var.bucket_name}"
   acl    = "public-read"
 
   website {

--- a/terraform-aws-static-site/main.tf
+++ b/terraform-aws-static-site/main.tf
@@ -103,6 +103,10 @@ resource "aws_cloudfront_distribution" "www_s3_distribution" {
     domain_name = aws_s3_bucket.www-bucket.bucket_regional_domain_name
     origin_id   = var.www_origin_id
 
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path
+    }
+    
     custom_origin_config {
       origin_protocol_policy = "http-only"
       http_port              = "80"

--- a/terraform-aws-static-site/main.tf
+++ b/terraform-aws-static-site/main.tf
@@ -42,7 +42,7 @@ resource "aws_s3_bucket" "www-bucket" {
 # Non www-bucket CDN
 resource "aws_cloudfront_distribution" "s3_distribution" {
   origin {
-    domain_name = var.domain_name
+    domain_name = aws_s3_bucket.b.bucket_regional_domain_name
     origin_id   = var.origin_id
 
     custom_origin_config {
@@ -94,12 +94,15 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
     response_code         = "200"
     response_page_path    = "/index.html"
   }
+  depends_on = [
+    aws_s3_bucket.b
+  ]
 }
 
 // www-bucket CDN
 resource "aws_cloudfront_distribution" "www_s3_distribution" {
   origin {
-    domain_name = var.www_domain_name
+    domain_name = aws_s3_bucket.www-bucket.bucket_regional_domain_name
     origin_id   = var.www_origin_id
 
     custom_origin_config {
@@ -151,6 +154,9 @@ resource "aws_cloudfront_distribution" "www_s3_distribution" {
     response_code         = "200"
     response_page_path    = "/index.html"
   }
+  depends_on = [
+    aws_s3_bucket.www-bucket
+  ]
 }
 
 

--- a/terraform-aws-static-site/main.tf
+++ b/terraform-aws-static-site/main.tf
@@ -32,7 +32,16 @@ resource "aws_s3_bucket_policy" "b" {
   policy = data.aws_iam_policy_document.b.json
 }
 
+# From /terraform-static-site-s3-bucket-redirect
 
+resource "aws_s3_bucket" "www-bucket" {
+  bucket = "www-${var.bucket_name}"
+  acl    = "public-read"
+
+  website {
+    redirect_all_requests_to = "https://${var.redirect_address}"
+  }
+}
 
 
 

--- a/terraform-aws-static-site/main.tf
+++ b/terraform-aws-static-site/main.tf
@@ -81,7 +81,8 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
   }
 
   viewer_certificate {
-    cloudfront_default_certificate = true
+    acm_certificate_arn = var.acm_arn
+    ssl_support_method  = "sni-only"
   }
 
   restrictions {
@@ -138,7 +139,8 @@ resource "aws_cloudfront_distribution" "www_s3_distribution" {
   }
 
   viewer_certificate {
-    cloudfront_default_certificate = true
+    acm_certificate_arn = var.acm_arn
+    ssl_support_method  = "sni-only"
   }
 
   restrictions {

--- a/terraform-aws-static-site/main.tf
+++ b/terraform-aws-static-site/main.tf
@@ -1,4 +1,3 @@
-# Non www-bucket
 resource "aws_s3_bucket" "non-www-bucket" {
   bucket = var.bucket_name
   acl    = "public-read"
@@ -30,7 +29,6 @@ resource "aws_s3_bucket_policy" "non-www-bucket" {
   policy = data.aws_iam_policy_document.non-www-bucket.json
 }
 
-# www-bucket
 resource "aws_s3_bucket" "www-bucket" {
   bucket = "www-${var.bucket_name}"
 
@@ -39,7 +37,6 @@ resource "aws_s3_bucket" "www-bucket" {
   }
 }
 
-# Non www-bucket CDN
 resource "aws_cloudfront_distribution" "s3_distribution" {
   origin {
     domain_name = aws_s3_bucket.non-www-bucket.bucket_regional_domain_name
@@ -101,7 +98,6 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
   }
 }
 
-// www-bucket CDN
 resource "aws_cloudfront_distribution" "www_s3_distribution" {
   origin {
     domain_name = aws_s3_bucket.www-bucket.bucket_regional_domain_name

--- a/terraform-aws-static-site/main.tf
+++ b/terraform-aws-static-site/main.tf
@@ -94,9 +94,6 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
     response_code         = "200"
     response_page_path    = "/index.html"
   }
-  depends_on = [
-    aws_s3_bucket.non-www-bucket
-  ]
 }
 
 // www-bucket CDN
@@ -154,9 +151,6 @@ resource "aws_cloudfront_distribution" "www_s3_distribution" {
     response_code         = "200"
     response_page_path    = "/index.html"
   }
-  depends_on = [
-    aws_s3_bucket.www-bucket
-  ]
 }
 
 

--- a/terraform-aws-static-site/main.tf
+++ b/terraform-aws-static-site/main.tf
@@ -73,9 +73,10 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
     }
 
     viewer_protocol_policy = "redirect-to-https"
+    compress               = true
     min_ttl                = 0
-    default_ttl            = 3600
-    max_ttl                = 86400
+    default_ttl            = 31557600
+    max_ttl                = 31557600
   }
 
   viewer_certificate {
@@ -130,9 +131,10 @@ resource "aws_cloudfront_distribution" "www_s3_distribution" {
     }
 
     viewer_protocol_policy = "redirect-to-https"
+    compress               = true
     min_ttl                = 0
-    default_ttl            = 3600
-    max_ttl                = 86400
+    default_ttl            = 31557600
+    max_ttl                = 31557600
   }
 
   viewer_certificate {

--- a/terraform-aws-static-site/main.tf
+++ b/terraform-aws-static-site/main.tf
@@ -14,7 +14,7 @@ data "aws_iam_policy_document" "non-www-bucket" {
 
     principals {
       type        = "AWS"
-      identifiers = ["*"]
+      identifiers = [aws_cloudfront_origin_access_identity.origin_access_identity.iam_arn]
     }
 
     actions   = ["s3:GetObject"]

--- a/terraform-aws-static-site/main.tf
+++ b/terraform-aws-static-site/main.tf
@@ -33,7 +33,6 @@ resource "aws_s3_bucket_policy" "non-www-bucket" {
 # www-bucket
 resource "aws_s3_bucket" "www-bucket" {
   bucket = "www-${var.bucket_name}"
-  acl    = "public-read"
 
   website {
     redirect_all_requests_to = "https://${var.redirect_address}"

--- a/terraform-aws-static-site/main.tf
+++ b/terraform-aws-static-site/main.tf
@@ -1,0 +1,38 @@
+provider "aws" {
+}
+
+# From /terraform-static-site-s3-bucket
+resource "aws_s3_bucket" "b" {
+  bucket = var.bucket_name
+  acl    = "public-read"
+
+  website {
+    index_document = "index.html"
+    error_document = "index.html"
+  }
+}
+
+data "aws_iam_policy_document" "b" {
+  statement {
+    sid    = "PublicReadGetObject"
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    actions   = ["s3:GetObject"]
+    resources = ["arn:aws:s3:::${var.bucket_name}/*"]
+  }
+}
+
+resource "aws_s3_bucket_policy" "b" {
+  bucket = aws_s3_bucket.b.id
+  policy = data.aws_iam_policy_document.b.json
+}
+
+
+
+
+

--- a/terraform-aws-static-site/main.tf
+++ b/terraform-aws-static-site/main.tf
@@ -43,5 +43,65 @@ resource "aws_s3_bucket" "www-bucket" {
   }
 }
 
+# From /terraform-static-site-cloudfront-distribution
+
+resource "aws_cloudfront_distribution" "s3_distribution" {
+  origin {
+    domain_name = var.domain_name
+    origin_id   = var.origin_id
+
+    custom_origin_config {
+      origin_protocol_policy = "http-only"
+      http_port              = "80"
+      https_port             = "443"
+      origin_ssl_protocols   = ["TLSv1"]
+    }
+  }
+
+  price_class = "PriceClass_100"
+
+  enabled = true
+
+  aliases = var.aliases
+
+  default_cache_behavior {
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = var.origin_id
+
+    forwarded_values {
+      query_string = true
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+  }
+
+  viewer_certificate {
+    acm_certificate_arn = var.acm_arn
+    ssl_support_method  = "sni-only"
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  custom_error_response {
+    error_caching_min_ttl = "0"
+    error_code            = "403"
+    response_code         = "200"
+    response_page_path    = "/index.html"
+  }
+}
+
+
 
 

--- a/terraform-aws-static-site/main.tf
+++ b/terraform-aws-static-site/main.tf
@@ -15,13 +15,15 @@ data "aws_iam_policy_document" "non-www-bucket" {
 
     principals {
       type        = "AWS"
-      identifiers = ["aws_cloudfront_origin_access_identity.origin_access_indentity.iam_arn"]
+      identifiers = [aws_cloudfront_origin_access_identity.origin_access_identity.iam_arn]
     }
 
     actions   = ["s3:GetObject"]
     resources = ["arn:aws:s3:::${var.bucket_name}/*"]
   }
 }
+
+resource "aws_cloudfront_origin_access_identity" "origin_access_identity" {}
 
 resource "aws_s3_bucket_policy" "non-www-bucket" {
   bucket = aws_s3_bucket.non-www-bucket.id
@@ -45,7 +47,7 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
     origin_id   = var.origin_id
 
     s3_origin_config {
-      origin_access_indentity= aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path
+      origin_access_identity = aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path
     }
 
     custom_origin_config {

--- a/terraform-aws-static-site/main.tf
+++ b/terraform-aws-static-site/main.tf
@@ -1,7 +1,3 @@
-provider "aws" {
-    region = "us-west-2"
-}
-
 # Non www-bucket
 resource "aws_s3_bucket" "b" {
   bucket = var.bucket_name

--- a/terraform-aws-static-site/main.tf
+++ b/terraform-aws-static-site/main.tf
@@ -11,12 +11,11 @@ resource "aws_s3_bucket" "non-www-bucket" {
 
 data "aws_iam_policy_document" "non-www-bucket" {
   statement {
-    sid    = "PublicReadGetObject"
     effect = "Allow"
 
     principals {
       type        = "AWS"
-      identifiers = ["*"]
+      identifiers = ["aws_cloudfront_origin_access_identity.origin_access_indentity.iam_arn"]
     }
 
     actions   = ["s3:GetObject"]
@@ -46,6 +45,7 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
     origin_id   = var.origin_id
 
     custom_origin_config {
+      origin_access_indentity= aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path
       origin_protocol_policy = "http-only"
       http_port              = "80"
       https_port             = "443"

--- a/terraform-aws-static-site/outputs.tf
+++ b/terraform-aws-static-site/outputs.tf
@@ -1,9 +1,0 @@
-# From /terraform-static-site-s3-bucket
-output "domain_name" {
-  value = aws_s3_bucket.b.website_endpoint
-}
-
-
-# From /terraform-static-site-s3-bucket-redirect
-
-# From /terraform-static-site-cloudfront-distribution

--- a/terraform-aws-static-site/outputs.tf
+++ b/terraform-aws-static-site/outputs.tf
@@ -1,0 +1,9 @@
+# From /terraform-static-site-s3-bucket
+output "domain_name" {
+  value = aws_s3_bucket.b.website_endpoint
+}
+
+
+# From /terraform-static-site-s3-bucket-redirect
+
+# From /terraform-static-site-cloudfront-distribution

--- a/terraform-aws-static-site/vars.tf
+++ b/terraform-aws-static-site/vars.tf
@@ -23,3 +23,7 @@ variable "www_aliases" {
   description = "cNAMEs for the distribution"
   type        = list(string)
 }
+
+variable "acm_arn" {
+  description = "The ARN of the certificate"
+}

--- a/terraform-aws-static-site/vars.tf
+++ b/terraform-aws-static-site/vars.tf
@@ -1,0 +1,3 @@
+variable "bucket_name" {
+    description = "The name of the S3 bucket"
+}

--- a/terraform-aws-static-site/vars.tf
+++ b/terraform-aws-static-site/vars.tf
@@ -1,3 +1,8 @@
 variable "bucket_name" {
     description = "The name of the S3 bucket"
 }
+
+variable "redirect_address" {
+  description = "The address to redirect requests to"
+}
+

--- a/terraform-aws-static-site/vars.tf
+++ b/terraform-aws-static-site/vars.tf
@@ -6,3 +6,22 @@ variable "redirect_address" {
   description = "The address to redirect requests to"
 }
 
+variable "origin_id" {
+  description = "The unique ID for the cloudfront distribution"
+}
+
+variable "domain_name" {
+  description = "The domain name for the cloudfront distribution"
+}
+
+variable "aliases" {
+  description = "cNAMEs for the distribution"
+  type        = list(string)
+}
+
+variable "acm_arn" {
+  description = "the arn of the certificate"
+}
+
+
+

--- a/terraform-aws-static-site/vars.tf
+++ b/terraform-aws-static-site/vars.tf
@@ -16,7 +16,7 @@ variable "aliases" {
 }
 
 variable "www_origin_id" {
-  description = "The unique ID for the cloudfront distribution"
+  description = "The unique ID for the www cloudfront distribution"
 }
 
 variable "www_aliases" {

--- a/terraform-aws-static-site/vars.tf
+++ b/terraform-aws-static-site/vars.tf
@@ -1,5 +1,9 @@
 variable "bucket_name" {
-    description = "The name of the S3 bucket"
+  description = "The name of the S3 bucket"
+}
+
+variable "www_bucket_name" {
+  description = "The name of the www S3 bucket"
 }
 
 variable "redirect_address" {
@@ -19,9 +23,15 @@ variable "aliases" {
   type        = list(string)
 }
 
-variable "acm_arn" {
-  description = "the arn of the certificate"
+variable "www_origin_id" {
+  description = "The unique ID for the cloudfront distribution"
 }
 
+variable "www_domain_name" {
+  description = "The domain name for the cloudfront distribution"
+}
 
-
+variable "www_aliases" {
+  description = "cNAMEs for the distribution"
+  type        = list(string)
+}

--- a/terraform-aws-static-site/vars.tf
+++ b/terraform-aws-static-site/vars.tf
@@ -10,10 +10,6 @@ variable "origin_id" {
   description = "The unique ID for the cloudfront distribution"
 }
 
-variable "domain_name" {
-  description = "The domain name for the cloudfront distribution"
-}
-
 variable "aliases" {
   description = "cNAMEs for the distribution"
   type        = list(string)
@@ -21,10 +17,6 @@ variable "aliases" {
 
 variable "www_origin_id" {
   description = "The unique ID for the cloudfront distribution"
-}
-
-variable "www_domain_name" {
-  description = "The domain name for the cloudfront distribution"
 }
 
 variable "www_aliases" {

--- a/terraform-aws-static-site/vars.tf
+++ b/terraform-aws-static-site/vars.tf
@@ -2,10 +2,6 @@ variable "bucket_name" {
   description = "The name of the S3 bucket"
 }
 
-variable "www_bucket_name" {
-  description = "The name of the www S3 bucket"
-}
-
 variable "redirect_address" {
   description = "The address to redirect requests to"
 }


### PR DESCRIPTION
# Summary
- Combined [terraform-static-site-s3-bucket](https://github.com/autotelic/infrastructure-modules/tree/master/terraform-static-site-s3-bucket), [terraform-static-site-s3-bucket-redirect](https://github.com/autotelic/infrastructure-modules/tree/master/terraform-static-site-s3-bucket-redirect), and [terraform-static-site-cloudfront-distribution](https://github.com/autotelic/infrastructure-modules/tree/master/terraform-static-site-cloudfront-distribution) into one module with a second CDN resource.